### PR TITLE
docs: prefer input in references

### DIFF
--- a/docs/.vitepress/components/TwoSlashRenderTabs.vue
+++ b/docs/.vitepress/components/TwoSlashRenderTabs.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-const tab = ref(0)
+const props = defineProps<{
+  preferInput?: boolean
+}>()
+
+const tab = ref(props.preferInput ? 1 : 0)
 
 function triggerResize() {
   // Workaround to floating-vue to force recalculation the floating position
@@ -12,7 +16,7 @@ function triggerResize() {
 
 <template>
   <div class="twoslash-render-tabs">
-    <div class="tabs" flex="~ gap-2" text-sm>
+    <div class="tabs" flex="~ gap-2" text-sm :class="preferInput ? 'flex-row-reverse justify-end' : ''">
       <button
         flex="~ gap-1 items-center" px2 py1
         border="b-solid 2 transparent" op50

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -32,11 +32,19 @@ export default defineConfig({
           if (!code.match(/\/\/ @|\^[?\|^]|---cut/))
             return _
 
+          let preferInput = false
+          options = options
+            .replace(/\binput\b/, () => {
+              preferInput = true
+              return ''
+            })
+            .trim()
+
           return [
-            '<TwoSlashRenderTabs>',
+            `<TwoSlashRenderTabs${preferInput ? ' :prefer-input="true"' : ''}>`,
             '<template #rendered>',
             '',
-            `${quotes}${lang} twoslash${options} [TwoSlash Rendered]`,
+            `${quotes}${lang} twoslash ${options} [TwoSlash Rendered]`,
             code,
             quotes,
             '',

--- a/docs/refs/notations.md
+++ b/docs/refs/notations.md
@@ -8,7 +8,7 @@ One of the key reasons for making Twoslash is the ability to use the TypeScript 
 
 Using `^?` you can pull out type information about a particular identifier in the line of code above it.
 
-```ts twoslash
+```ts twoslash input
 const hi = 'Hello'
 const msg = `${hi}, world`
 //    ^?
@@ -18,7 +18,7 @@ const msg = `${hi}, world`
 
 Using `^|` you can pull out information about a what the auto-complete looks like at a particular location.
 
-```ts twoslash
+```ts twoslash input
 // @noErrors
 console.e
 //       ^|
@@ -30,13 +30,13 @@ So, in this case, Twoslash asks TypeScript for completions of `console`, then fi
 
 ## Cutting a Code Sample
 
-Every Twoslash code sample needs to be a complete TypeScript program realistically, basically it needs to compile. Quite often to make it compile, there is a bunch of code which isn't relevant to the user. This can be extracted out of the code sample via `// ---cut---` which removes all of the code above it from the output.
+Every Twoslash code sample needs to be a complete TypeScript program realistically, basically it needs to compile. Quite often to make it compile, there is a bunch of code which isn't relevant to the user. This can be extracted out of the code sample via the following sigils to remove code from the output.
 
-### `---cut---`
+### `// ---cut-before---`
 
-Cut works after TypeScript has generated the project and pulled out all the editor information (like identifiers, queries, highlights etc) and then amends all of their offsets and lines to re-fit the smaller output. What your user sees is everything below the `---cut---`.
+Cut works after TypeScript has generated the project and pulled out all the editor information (like identifiers, queries, highlights etc) and then amends all of their offsets and lines to re-fit the smaller output. What your user sees is everything below the `// ---before-cut---`. A shorthand `// ---cut---` is also available.
 
-```ts twoslash
+```ts twoslash input
 const level: string = 'Danger'
 // ---cut---
 console.log(level)
@@ -44,7 +44,7 @@ console.log(level)
 
 Would only show a single line.
 
-```ts twoslash
+```ts twoslash input
 // @filename: a.ts
 export const helloWorld: string = 'Hi'
 // ---cut---
@@ -56,17 +56,45 @@ console.log(helloWorld)
 
 Would only show the last two lines, but to TypeScript it was a program with 2 files and all of the IDE information is hooked up correctly across the files. This is why `// @filename: [file]` is specifically the only Twoslash command which _is not_ removed, because if it's not relevant it can be `---cut---` away.
 
-### `---cut-after---`
+### `// ---cut-after---`
 
-The sibling to `---cut---` which trims anything after the sigil:
+The sibling to `// ---cut-before---` which trims anything after the sigil:
 
-<!-- eslint-skip -->
-```ts twoslash
+```ts twoslash input
 const level: string = 'Danger'
-// ---cut---
+// ---cut-before---
 console.log(level)
 // ---cut-after---
 console.log('This is not shown')
+```
+
+### `// ---cut-start---` and `// ---cut-end---`
+
+You can also use `// ---cut-start---` and `// ---cut-end---` paris to cut out sections of code in between the two sigils.
+
+```ts twoslash input
+const level: string = 'Danger'
+// ---cut-start---
+console.log(level) // This is not shown
+// ---cut-end---
+console.log('This is shown')
+```
+
+Multiple instances are supported to cut out multiple sections, but the sigils must comes in pairs.
+
+## Overriding Options
+
+Using the `// @name` and `// @name: value` notations to override the [compiler options](/refs/options#compiler-options) for TypeScript language features and [handbook options](/refs/options#handbook-options) for TwoSlash. The notations will be removed from the output.
+
+For example:
+
+```ts twoslash input
+// @noImplicitAny: false
+// @target: esnext
+// @lib: esnext
+// This suppose to throw an error,
+// but it won't because we disabled noImplicitAny
+const fn = a => a + 1
 ```
 
 ## Showing the Emitted Files
@@ -77,7 +105,7 @@ Running a Twoslash code sample is a full TypeScript compiler run, and that run w
 
 `// @showEmit` is the main command to tell Shiki Twoslash that you want to replace the output of your code sample with the equivalent `.js` file.
 
-```ts twoslash
+```ts twoslash input
 // @showEmit
 const level: string = 'Danger'
 ```
@@ -88,7 +116,7 @@ Would show the `.js` file which this `.ts` file represents. You can see TypeScri
 
 While the `.js` file is probably the most useful file out of the box, TypeScript does emit other files if you have the right flags enabled (`.d.ts` and `.map`) but also when you have a multi-file code sample - you might need to tell Twoslash which file to show. For all these cases you can _also_ add `@showEmittedFile: [file]` to tell Shiki Twoslash which file you want to show.
 
-```ts twoslash
+```ts twoslash input
 // @declaration
 // @showEmit
 // @showEmittedFile: index.d.ts
@@ -97,7 +125,7 @@ export const hello = 'world'
 
 > Shows the `.d.ts` for a TypeScript code sample
 
-```ts
+```ts twoslash input
 // @sourceMap
 // @showEmit
 // @showEmittedFile: index.js.map
@@ -116,7 +144,7 @@ export const hello = 'world'
 
 > Shows the `.map` for a `.d.ts` (mainly used for project references)
 
-```ts
+```ts twoslash input
 // @showEmit
 // @showEmittedFile: b.js
 // @filename: a.ts

--- a/docs/refs/options.md
+++ b/docs/refs/options.md
@@ -4,6 +4,8 @@
 
 Options of [TypeScript Compiler Options](https://www.typescriptlang.org/tsconfig#compilerOptions).
 
+TwoSlash comes with a set of default compiler options that [can be found here](https://github.com/twoslashes/twoslash/blob/main/packages/twoslash/src/defaults.ts).
+
 ## Handbook Options
 
 Check the [type definition](https://github.com/antfu/twoslashes/blob/main/packages/twoslash/src/types/handbook-options.ts) for the full list of options.
@@ -12,7 +14,7 @@ Check the [type definition](https://github.com/antfu/twoslashes/blob/main/packag
 
 TypeScript error codes to be presented in the code. Use space to separate multiple error codes.
 
-```ts twoslash
+```ts twoslash input
 // @errors: 2322 2588
 const str: string = 1
 str = 'Hello'
@@ -22,7 +24,7 @@ str = 'Hello'
 
 Suppress errors in the code. Or provide error codes to suppress specific errors.
 
-```ts twoslash
+```ts twoslash input
 // @noErrors
 const str: string = 1
 str = 'Hello'
@@ -32,7 +34,7 @@ str = 'Hello'
 
 Ignore errors that occurred in the cutted code.
 
-```ts twoslash
+```ts twoslash input
 // @noErrorsCutted
 const hello = 'world'
 // ---cut-after---
@@ -47,9 +49,17 @@ Disable error validation, the errors will still be rendered but TwoSlash will no
 
 Tell TwoSlash to not remove any notations, and keep the original code untouched. The `nodes` will have the position information of the original code. Useful for better source mapping combing with `meta.removals`.
 
-```ts twoslash
+```ts twoslash input
 // @keepNotations
 // @module: esnext
 // @errors: 2322
 const str: string = 1
 ```
+
+### `showEmit`
+
+Learn more in the [Showing the Emitted Files](/refs/notations#showing-the-emitted-files) section.
+
+### `showEmittedFile`
+
+Learn more in the [Showing the Emitted Files](/refs/notations#showing-the-emitted-files) section.


### PR DESCRIPTION
This PR adds references for more notations.

Also made the `input` modifier to code snippet so the code tabs can show the input at initial rendering:

<img width="799" alt="image" src="https://github.com/twoslashes/twoslash/assets/11247099/f9bdf2c9-043a-4f43-9688-d07786d83526">

