### PR TITLE
feat: expose jsdocs tags info

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@typescript/twoslash": "^3.2.4",
     "@typescript/vfs": "1.5.0",
     "@vitest/coverage-v8": "^1.2.0",
+    "@vueuse/core": "^10.7.2",
     "bumpp": "^9.2.1",
     "eslint": "^8.56.0",
     "esno": "^4.0.0",

--- a/packages/twoslash-vue/test/query.test.ts
+++ b/packages/twoslash-vue/test/query.test.ts
@@ -50,6 +50,7 @@ describe('basic', () => {
           "length": 8,
           "line": 2,
           "start": 40,
+          "tags": undefined,
           "target": "computed",
           "text": "(alias) const computed: {
             <T>(getter: ComputedGetter<T>, debugOptions?: DebuggerOptions | undefined): ComputedRef<T>;

--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -141,13 +141,14 @@ export function createTwoslasher(createOptions: CreateTwoslashOptions = {}): Two
       if (quickInfo && quickInfo.displayParts) {
         const text = quickInfo.displayParts.map(dp => dp.text).join('')
 
-        // TODO: get different type of docs
         const docs = quickInfo.documentation?.map(d => d.text).join('\n') || undefined
+        const tags = quickInfo.tags?.map(t => [t.name, t.text?.map(i => i.text).join('')] as [string, string | undefined])
 
         return {
           type: 'hover',
           text,
           docs,
+          tags,
           start,
           length: target.length,
           target,

--- a/packages/twoslash/src/types/nodes.ts
+++ b/packages/twoslash/src/types/nodes.ts
@@ -22,6 +22,8 @@ export interface NodeHover extends NodeBase {
   text: string
   /** Attached JSDoc info */
   docs?: string
+  /** JSDoc tags */
+  tags?: [name: string, text: string | undefined][]
 }
 
 export interface NodeHighlight extends Omit<NodeHover, 'type'> {

--- a/packages/twoslash/test/fixtures/tests/jsdoc_links.ts
+++ b/packages/twoslash/test/fixtures/tests/jsdoc_links.ts
@@ -1,0 +1,1 @@
+import { onKeyPressed } from '@vueuse/core'

--- a/packages/twoslash/test/results/tests/jsdoc_links.json
+++ b/packages/twoslash/test/results/tests/jsdoc_links.json
@@ -1,0 +1,34 @@
+{
+  "code": "import { onKeyPressed } from '@vueuse/core'\n",
+  "nodes": [
+    {
+      "type": "hover",
+      "text": "(alias) function onKeyPressed(key: KeyFilter, handler: (event: KeyboardEvent) => void, options?: Omit<OnKeyStrokeOptions, 'eventName'>): () => void\nimport onKeyPressed",
+      "docs": "Listen to the keypress event of the given key.",
+      "tags": [
+        [
+          "see",
+          "https://vueuse.org/onKeyStroke"
+        ],
+        [
+          "param",
+          "key"
+        ],
+        [
+          "param",
+          "handler"
+        ],
+        [
+          "param",
+          "options"
+        ]
+      ],
+      "start": 9,
+      "length": 12,
+      "target": "onKeyPressed",
+      "line": 0,
+      "character": 9
+    }
+  ],
+  "flags": []
+}

--- a/packages/twoslash/test/results/tests/preact.json
+++ b/packages/twoslash/test/results/tests/preact.json
@@ -4,6 +4,12 @@
     {
       "type": "hover",
       "text": "function App(): JSXInternal.Element",
+      "tags": [
+        [
+          "jsxImportSource",
+          "preact"
+        ]
+      ],
       "start": 41,
       "length": 3,
       "target": "App",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.2.0
         version: 1.2.0(vitest@1.2.0)
+      '@vueuse/core':
+        specifier: ^10.7.2
+        version: 10.7.2(vue@3.4.14)
       bumpp:
         specifier: ^9.2.1
         version: 9.2.1
@@ -1659,7 +1662,6 @@ packages:
 
   /@types/web-bluetooth@0.0.20:
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
-    dev: false
 
   /@typescript-eslint/eslint-plugin@6.18.1(@typescript-eslint/parser@6.18.1)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==}
@@ -2223,7 +2225,6 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
-    dev: false
 
   /@vueuse/integrations@10.7.2(focus-trap@7.5.4)(fuse.js@7.0.0)(vue@3.4.14):
     resolution: {integrity: sha512-+u3RLPFedjASs5EKPc69Ge49WNgqeMfSxFn+qrQTzblPXZg6+EFzhjarS5edj2qAf6xQ93f95TUxRwKStXj/sQ==}
@@ -2278,7 +2279,6 @@ packages:
 
   /@vueuse/metadata@10.7.2:
     resolution: {integrity: sha512-kCWPb4J2KGrwLtn1eJwaJD742u1k5h6v/St5wFe8Quih90+k2a0JP8BS4Zp34XUuJqS2AxFYMb1wjUL8HfhWsQ==}
-    dev: false
 
   /@vueuse/shared@10.7.2(vue@3.4.14):
     resolution: {integrity: sha512-qFbXoxS44pi2FkgFjPvF4h7c9oMDutpyBdcJdMYIMg9XyXli2meFMuaKn+UMgsClo//Th6+beeCgqweT/79BVA==}
@@ -2287,7 +2287,6 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
-    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.11.3):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -6575,7 +6574,6 @@ packages:
         optional: true
     dependencies:
       vue: 3.4.14(typescript@5.3.3)
-    dev: false
 
   /vue-eslint-parser@9.4.0(eslint@8.56.0):
     resolution: {integrity: sha512-7KsNBb6gHFA75BtneJsoK/dbZ281whUIwFYdQxA68QrCrGMXYzUMbPDHGcOQ0OocIVKrWSKWXZ4mL7tonCXoUw==}


### PR DESCRIPTION
Expose jsdocs tags info so the renderer could display them - align more with how users would see in VS Code:

<img width="718" alt="Screenshot 2024-01-16 at 18 00 59" src="https://github.com/twoslashes/twoslash/assets/11247099/0e0978c0-0407-4406-a0af-a1bc1d6c95c7">