### PR TITLE
fix!: rework highlight node

### DIFF
--- a/packages/twoslash-vue/src/index.ts
+++ b/packages/twoslash-vue/src/index.ts
@@ -85,7 +85,7 @@ export function createTwoslasher(createOptions: CreateTwoslashVueOptions = {}): 
       removals: [] as Range[],
       positionCompletions: [] as number[],
       positionQueries: [] as number[],
-      positionHighlights: [] as Range[],
+      positionHighlights: [] as TwoslashReturnMeta['positionHighlights'],
       flagNotations: [] as ParsedFlagNotation[],
     } satisfies Partial<TwoslashReturnMeta>
 

--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -2,7 +2,7 @@ import type { CompilerOptions, CompletionEntry, CompletionTriggerKind, JsxEmit }
 import { createFSBackedSystem, createSystem, createVirtualTypeScriptEnvironment } from '@typescript/vfs'
 import { TwoslashError } from './error'
 import type { CompilerOptionDeclaration, CreateTwoslashOptions, NodeError, NodeWithoutPosition, Position, Range, TwoslashExecuteOptions, TwoslashInstance, TwoslashOptions, TwoslashReturn, TwoslashReturnMeta, VirtualFile } from './types'
-import { areRangesIntersecting, createPositionConverter, findCutNotations, findFlagNotations, findQueryMarkers, getExtension, getIdentifierTextSpans, getObjectHash, isInRange, isInRanges, removeCodeRanges, removeTsExtension, resolveNodePositions, splitFiles, typesToExtension } from './utils'
+import { createPositionConverter, findCutNotations, findFlagNotations, findQueryMarkers, getExtension, getIdentifierTextSpans, getObjectHash, isInRange, isInRanges, removeCodeRanges, removeTsExtension, resolveNodePositions, splitFiles, typesToExtension } from './utils'
 import { validateCodeForErrors } from './validation'
 import { defaultCompilerOptions, defaultHandbookOptions } from './defaults'
 

--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -239,35 +239,12 @@ export function createTwoslasher(createOptions: CreateTwoslashOptions = {}): Two
 
       // #region get highlights
       for (const highlight of meta.positionHighlights) {
-        if (isInRemoval(highlight[0])) {
-          throw new TwoslashError(
-            `Invalid highlight query`,
-            `The request on line ${pc.indexToPos(highlight[0]).line + 2} for highlight via ^^^ is in a removal range.`,
-            `This is likely that the positioning is off.`,
-          )
-        }
-
-        const file = getFileAtPosition(highlight[0])!
-        const identifiers = getIdentifiersOfFile(file)
-
-        const ids = identifiers.filter(i => areRangesIntersecting(i as unknown as Range, highlight))
-        const matched = ids
-          .map(i => getQuickInfo(file, i[0], i[2]))
-          .filter(Boolean) as NodeWithoutPosition[]
-        if (matched.length) {
-          for (const node of matched) {
-            node.type = 'highlight'
-            nodes.push(node)
-          }
-        }
-        else {
-          const pos = pc.indexToPos(highlight[0])
-          throw new TwoslashError(
-            `Invalid highlight query`,
-            `The request on line ${pos.line + 2} in ${file.filename} for highlight via ^^^ is returned nothing from the compiler.`,
-            `This is likely that the positioning is off.`,
-          )
-        }
+        nodes.push({
+          type: 'highlight',
+          start: highlight[0],
+          length: highlight[1] - highlight[0],
+          text: highlight[2],
+        })
       }
       // #endregion
 

--- a/packages/twoslash/src/legacy.ts
+++ b/packages/twoslash/src/legacy.ts
@@ -136,11 +136,12 @@ export function convertLegacyReturn(result: TwoslashReturn): TwoslashReturnLegac
     highlights: result.highlights
       .map((h): TwoslashReturnLegacy['highlights'][0] => ({
         kind: 'highlight',
-        offset: h.character,
-        start: h.start,
+        // it's a bit confusing that `offset` and `start` are flipped
+        offset: h.start,
+        start: h.character,
         length: h.length,
         line: h.line,
-        text: h.text,
+        text: h.text || '',
       })),
 
     queries: ([

--- a/packages/twoslash/src/types/nodes.ts
+++ b/packages/twoslash/src/types/nodes.ts
@@ -26,8 +26,10 @@ export interface NodeHover extends NodeBase {
   tags?: [name: string, text: string | undefined][]
 }
 
-export interface NodeHighlight extends Omit<NodeHover, 'type'> {
+export interface NodeHighlight extends NodeBase {
   type: 'highlight'
+  /** The annotation message */
+  text?: string
 }
 
 export interface NodeQuery extends Omit<NodeHover, 'type'> {

--- a/packages/twoslash/src/types/returns.ts
+++ b/packages/twoslash/src/types/returns.ts
@@ -60,7 +60,7 @@ export interface TwoslashReturnMeta {
   /**
    * Positions of errors in the code
    */
-  positionHighlights: Range[]
+  positionHighlights: [start: number, end: number, text?: string][]
 }
 
 export interface ParsedFlagNotation {

--- a/packages/twoslash/src/utils.ts
+++ b/packages/twoslash/src/utils.ts
@@ -443,6 +443,7 @@ export function findQueryMarkers(
         meta.positionHighlights.push([
           targetIndex,
           targetIndex + markerLength,
+          match[2]?.trim(),
         ])
       }
     })

--- a/packages/twoslash/test/fixtures/throws/invalid-highlights.ts
+++ b/packages/twoslash/test/fixtures/throws/invalid-highlights.ts
@@ -1,3 +1,0 @@
-const a = 1;
-//          ^^^
-console.log(a);

--- a/packages/twoslash/test/legacy.test.ts
+++ b/packages/twoslash/test/legacy.test.ts
@@ -8,6 +8,8 @@ describe('legacy', async () => {
   await compareCode('./fixtures/examples/cuts-out-unnecessary-code.ts')
   await compareCode('./fixtures/examples/errors-with-generics.ts')
   await compareCode('./fixtures/examples/completions-basic.ts')
+  await compareCode('./fixtures/examples/highlighting.ts')
+  await compareCode('./fixtures/tests/inline-highlights.ts')
 
   async function compareCode(path: string) {
     const code = await fs.readFile(new URL(path, import.meta.url), 'utf-8')
@@ -19,8 +21,8 @@ describe('legacy', async () => {
       function cleanup(t: any) {
         delete t.playgroundURL
 
-        // We have different calculations for queries, that are not trivial to map back
         t.queries.forEach((i: any) => {
+          // We have different calculations for queries, that are not trivial to map back
           delete i.start
           delete i.length
           delete i.text
@@ -28,7 +30,13 @@ describe('legacy', async () => {
         })
 
         t.errors.forEach((i: any) => {
+          // Id has a bit different calculation, as long as it's unique, it should be fine
           delete i.id
+        })
+
+        t.highlights.forEach((i: any) => {
+          // It seems the legacy version's line numbers are off for the second highlight nations
+          delete i.line
         })
 
         return t

--- a/packages/twoslash/test/results/examples/highlighting.json
+++ b/packages/twoslash/test/results/examples/highlighting.json
@@ -96,12 +96,10 @@
     },
     {
       "type": "highlight",
-      "text": "var Date: DateConstructor\nnew () => Date (+4 overloads)",
-      "start": 138,
-      "length": 4,
-      "target": "Date",
+      "start": 134,
+      "length": 10,
       "line": 4,
-      "character": 22
+      "character": 18
     },
     {
       "type": "hover",

--- a/packages/twoslash/test/results/tests/inline-highlights.json
+++ b/packages/twoslash/test/results/tests/inline-highlights.json
@@ -3,10 +3,8 @@
   "nodes": [
     {
       "type": "highlight",
-      "text": "type Result = \"pass\" | \"fail\"",
       "start": 5,
       "length": 6,
-      "target": "Result",
       "line": 0,
       "character": 5
     },
@@ -21,10 +19,9 @@
     },
     {
       "type": "highlight",
-      "text": "const hello: \"OK\"",
       "start": 37,
-      "length": 5,
-      "target": "hello",
+      "length": 2,
+      "text": "Sure",
       "line": 2,
       "character": 6
     },

--- a/packages/twoslash/test/results/throws/invalid-highlights.txt
+++ b/packages/twoslash/test/results/throws/invalid-highlights.txt
@@ -1,6 +1,0 @@
-
-## Invalid highlight query
-
-The request on line 2 in index.ts for highlight via ^^^ is returned nothing from the compiler.
-
-This is likely that the positioning is off.


### PR DESCRIPTION
Now, it simply marks the range for highlighting, align with the previous behavior. Previously, I had a wrong understanding of how it works.