### PR TITLE
fix: check for undefined

### DIFF
--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -315,8 +315,8 @@ export function createTwoslasher(createOptions: CreateTwoslashOptions = {}): Two
               includeCompletionsForModuleExports: false,
             })
             completions = result?.entries ?? []
-            if (completions[0].replacementSpan?.length) {
-              prefix = (completions[0]?.replacementSpan && code.slice(
+            if (completions[0]?.replacementSpan?.length) {
+              prefix = (code.slice(
                 completions[0].replacementSpan.start,
                 target,
               )) || prefix


### PR DESCRIPTION
Hello, I don't have a reproduction for this. I encounter it only when deploying on Cloudflare. Looking at the code, it seems that this could be caught with TS with `noUncheckedIndexedAccess`.

<img width="1129" alt="Screenshot 2024-02-12 at 21 28 32" src="https://github.com/twoslashes/twoslash/assets/664177/cf7ccbdc-40b8-4766-853e-7ec046e7b236">

I didn't dig into the code, I just did a search of the property that was failing so the commit is very generic, sorry about that
