### PR TITLE
feat: make twoslash package asyncable

### DIFF
--- a/packages/twoslash-cdn/src/index.ts
+++ b/packages/twoslash-cdn/src/index.ts
@@ -75,7 +75,7 @@ export interface TwoslashCdnReturn {
   fetcher: typeof fetch
 }
 
-export function createTwoslashFromCDN(options: TwoslashCdnOptions = {}): TwoslashCdnReturn {
+export async function createTwoslashFromCDN(options: TwoslashCdnOptions = {}): Promise<TwoslashCdnReturn> {
   const fetcher = (
     options.storage
       ? createCachedFetchFromStorage(options.storage, options.fetcher || fetch)
@@ -124,7 +124,7 @@ export function createTwoslashFromCDN(options: TwoslashCdnOptions = {}): Twoslas
     ])
   }
 
-  const twoslasher = createTwoslasher({
+  const twoslasher = await createTwoslasher({
     ...options.twoSlashOptionsOverrides,
     tsModule: ts,
     fsMap,
@@ -132,7 +132,10 @@ export function createTwoslashFromCDN(options: TwoslashCdnOptions = {}): Twoslas
 
   async function run(source: string, extension?: string, localOptions?: TwoslashExecuteOptions) {
     await prepareTypes(source)
-    return runSync(source, extension, localOptions)
+    return twoslasher(source, extension, {
+      ...options.twoSlashOptionsOverrides,
+      ...localOptions,
+    })
   }
 
   function runSync(source: string, extension?: string, localOptions?: TwoslashExecuteOptions) {

--- a/packages/twoslash-vue/src/index.ts
+++ b/packages/twoslash-vue/src/index.ts
@@ -48,8 +48,8 @@ export interface TwoslashVueExecuteOptions extends TwoslashExecuteOptions, VueSp
 /**
  * Create a twoslasher instance that add additional support for Vue SFC.
  */
-export function createTwoslasher(createOptions: CreateTwoslashVueOptions = {}): TwoslashInstance {
-  const twoslasherBase = createTwoslasherBase(createOptions)
+export async function createTwoslasher(createOptions: CreateTwoslashVueOptions = {}): Promise<TwoslashInstance> {
+  const twoslasherBase = await createTwoslasherBase(createOptions)
   const cache = twoslasherBase.getCacheMap() as any as Map<string, ReturnType<typeof createVueLanguage>> | undefined
   const tsOptionDeclarations = (ts as any).optionDeclarations as CompilerOptionDeclaration[]
 

--- a/packages/twoslash-vue/test/fixtures.test.ts
+++ b/packages/twoslash-vue/test/fixtures.test.ts
@@ -19,7 +19,7 @@ const filters: RegExp[] = [
 if (process.env.CI && filters.length)
   throw new Error('Should not filters fixture tests in CI, did you forget to remove them?')
 
-const twoslasher = createTwoslasher()
+const twoslasher = await createTwoslasher()
 
 Object.entries(fixtures).forEach(([path, fixture]) => {
   path = path.replace(/\\/g, '/')

--- a/packages/twoslash-vue/test/query.test.ts
+++ b/packages/twoslash-vue/test/query.test.ts
@@ -3,7 +3,7 @@ import { createTwoslasher } from '../src/index'
 
 const code = await import('./fixtures/query-basic.vue?raw').then(m => m.default)
 
-const twoslasher = createTwoslasher()
+const twoslasher = await createTwoslasher()
 
 describe('basic', () => {
   const result = twoslasher(code, 'vue')

--- a/packages/twoslash-vue/test/shikiji.test.ts
+++ b/packages/twoslash-vue/test/shikiji.test.ts
@@ -13,7 +13,7 @@ const styleHeader = [
   '',
 ].join('\n')
 
-const twoslasherVue = createTwoslasher()
+const twoslasherVue = await createTwoslasher()
 
 it('highlight vue', async () => {
   const result = await codeToHtml(code, {
@@ -33,7 +33,7 @@ it('highlight vue', async () => {
     .toMatchFileSnapshot('./results/renderer/example.vue.html')
 })
 
-const twoslasherRaw = createTwoslasher({
+const twoslasherRaw = await createTwoslasher({
   debugShowGeneratedCode: true,
 })
 

--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -15,7 +15,7 @@ type TS = typeof import('typescript')
 /**
  * Create a Twoslash instance with cached TS environments
  */
-export function createTwoslasher(createOptions: CreateTwoslashOptions = {}): TwoslashInstance {
+export function createTwoslasher(createOptions: CreateTwoslashOptions = {}): TwoslashInstance | Promise<TwoslashInstance> {
   const ts: TS = createOptions.tsModule!
   const tsOptionDeclarations = (ts as any).optionDeclarations as CompilerOptionDeclaration[]
 
@@ -510,11 +510,11 @@ export function createTwoslasher(createOptions: CreateTwoslashOptions = {}): Two
  *
  * It's recommended to use `createTwoslash` for better performance on multiple runs
  */
-export function twoslasher(code: string, lang?: string, opts?: Partial<TwoslashOptions>) {
-  return createTwoslasher({
+export async function twoslasher(code: string, lang?: string, opts?: Partial<TwoslashOptions>) {
+  return (await createTwoslasher({
     ...opts,
     cache: false,
-  })(code, lang)
+  }))(code, lang)
 }
 
 function diagnosticCategoryToErrorLevel(e: DiagnosticCategory): ErrorLevel | undefined {

--- a/packages/twoslash/src/index.ts
+++ b/packages/twoslash/src/index.ts
@@ -37,9 +37,9 @@ export function twoslasher(code: string, lang: string, opts?: TwoslashOptions) {
  *
  * @deprecated migrate to `twoslasher` instead
  */
-export function twoslasherLegacy(code: string, lang: string, opts?: TwoslashOptionsLegacy): TwoslashReturnLegacy {
+export async function twoslasherLegacy(code: string, lang: string, opts?: TwoslashOptionsLegacy): Promise<TwoslashReturnLegacy> {
   return convertLegacyReturn(
-    _twoslasher(code, lang, convertLegacyOptions({
+    await _twoslasher(code, lang, convertLegacyOptions({
       vfsRoot: cwd,
       tsModule: ts,
       ...opts,

--- a/packages/twoslash/test/compiler_options.test.ts
+++ b/packages/twoslash/test/compiler_options.test.ts
@@ -2,7 +2,7 @@ import { ModuleKind } from 'typescript'
 import { expect, it } from 'vitest'
 import { twoslasher } from '../src/index'
 
-it('emits CommonJS', () => {
+it('emits CommonJS', async () => {
   const files = `
 // @filename: file-with-export.ts
 export const helloWorld = "Example string";
@@ -11,7 +11,7 @@ export const helloWorld = "Example string";
 import {helloWorld} from "./file-with-export"
 console.log(helloWorld)
 `
-  const result = twoslasher(files, 'ts', {
+  const result = await twoslasher(files, 'ts', {
     handbookOptions: { showEmit: true },
     compilerOptions: { module: ModuleKind.CommonJS },
   })

--- a/packages/twoslash/test/custom_transformers.test.ts
+++ b/packages/twoslash/test/custom_transformers.test.ts
@@ -3,7 +3,7 @@ import { isSourceFile, isStringLiteral, visitEachChild, visitNode } from 'typesc
 import { expect, it } from 'vitest'
 import { twoslasher } from '../src/index'
 
-it('applies custom transformers', () => {
+it('applies custom transformers', async () => {
   const code = 'console.log(\'Hello World!\')'
   // A simple transformer that uppercases all string literals
   const transformer: TransformerFactory<SourceFile> = (ctx: TransformationContext) => {
@@ -15,7 +15,7 @@ it('applies custom transformers', () => {
     return node => visitNode(node, visitor, isSourceFile)
   }
 
-  const result = twoslasher(code, 'ts', {
+  const result = await twoslasher(code, 'ts', {
     handbookOptions: { showEmit: true },
     customTransformers: {
       before: [transformer],

--- a/packages/twoslash/test/cutting.test.ts
+++ b/packages/twoslash/test/cutting.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { twoslasher } from '../src/index'
 
-describe('supports hiding the example code', () => {
+describe('supports hiding the example code', async () => {
   const file = `
 const a = "123"
 // ---cut---
 const b = "345"
 `
-  const result = twoslasher(file, 'ts')
+  const result = await twoslasher(file, 'ts')
 
   it('hides the right code', () => {
     // Has the right code shipped
@@ -28,7 +28,7 @@ const b = "345"
   })
 })
 
-describe('supports hiding the example code with multi-files', () => {
+describe('supports hiding the example code with multi-files', async () => {
   const file = `
 // @filename: main-file.ts
 const a = "123"
@@ -36,7 +36,7 @@ const a = "123"
 // ---cut---
 const b = "345"
 `
-  const result = twoslasher(file, 'ts')
+  const result = await twoslasher(file, 'ts')
 
   it('shows the right LSP results', () => {
     expect(result.hovers.find(info => info.text.includes('const a'))).toBeUndefined()
@@ -51,14 +51,14 @@ const b = "345"
   })
 })
 
-describe('supports handling queries in cut code', () => {
+describe('supports handling queries in cut code', async () => {
   const file = `
 const a = "123"
 // ---cut---
 const b = "345"
 //    ^?
 `
-  const result = twoslasher(file, 'ts')
+  const result = await twoslasher(file, 'ts')
 
   it('shows the right query results', () => {
     const bLSPResult = result.queries.find(info => info.line === 0)
@@ -67,7 +67,7 @@ const b = "345"
   })
 })
 
-describe('supports handling a query in cut multi-file code', () => {
+describe('supports handling a query in cut multi-file code', async () => {
   const file = `
 // @filename: index.ts
 const a = "123"
@@ -77,7 +77,7 @@ const b = "345"
 const c = "678"
 //    ^?
 `
-  const result = twoslasher(file, 'ts')
+  const result = await twoslasher(file, 'ts')
 
   it('shows the right query results', () => {
     const bQueryResult = result.queries.find(info => info.line === 0)
@@ -86,13 +86,13 @@ const c = "678"
   })
 })
 
-describe('supports hiding after a line', () => {
+describe('supports hiding after a line', async () => {
   const file = `
 const a = "123"
 // ---cut-after---
 const b = "345"
 `
-  const result = twoslasher(file, 'ts')
+  const result = await twoslasher(file, 'ts')
 
   it('hides the right code', () => {
     // Has the right code shipped

--- a/packages/twoslash/test/extra-files.test.ts
+++ b/packages/twoslash/test/extra-files.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { twoslasher } from '../src/index'
 
 describe('supports extra-files', () => {
-  it('prepend & append', () => {
+  it('prepend & append', async () => {
     const file = `
 const a = ref(1)
     `.trim()
-    const result = twoslasher(file, 'ts', {
+    const result = await twoslasher(file, 'ts', {
       extraFiles: {
         'index.ts': {
           prepend: 'function ref<T>(value: T): Ref<T> { return { value } }\n',
@@ -33,14 +33,14 @@ const a = ref(1)
       `)
   })
 
-  it('extra file', () => {
+  it('extra file', async () => {
     const file = `
 import { ref } from './foo'
 const a = ref(1)
 a.value = 'foo'
     `.trim()
 
-    const result = twoslasher(file, 'ts', {
+    const result = await twoslasher(file, 'ts', {
       extraFiles: {
         'foo.ts': 'export function ref<T>(value: T): Ref<T> { return { value } }\ninterface Ref<T> { value: string }',
       },

--- a/packages/twoslash/test/fixtures.test.ts
+++ b/packages/twoslash/test/fixtures.test.ts
@@ -19,7 +19,7 @@ const filters: RegExp[] = [
 if (process.env.CI && filters.length)
   throw new Error('Should not filters fixture tests in CI, did you forget to remove them?')
 
-const twoslasher = createTwoslasher()
+const twoslasher = await createTwoslasher()
 
 Object.entries(fixtures).forEach(([path, fixture]) => {
   path = path.replace(/\\/g, '/')

--- a/packages/twoslash/test/highlights.test.ts
+++ b/packages/twoslash/test/highlights.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest'
 import { twoslasher } from '../src/index'
 
-it('supports highlighting something', () => {
+it('supports highlighting something', async () => {
   const file = `
 const a = "123"
 //    ^^^^^^^^^
 const b = "345"
 `
-  const result = twoslasher(file, 'ts')
+  const result = await twoslasher(file, 'ts')
   expect(result.highlights.length).toEqual(1)
 })

--- a/packages/twoslash/test/legacy.test.ts
+++ b/packages/twoslash/test/legacy.test.ts
@@ -15,7 +15,7 @@ describe('legacy', async () => {
     const code = await fs.readFile(new URL(path, import.meta.url), 'utf-8')
 
     it(`compare ${basename(path)}`, async () => {
-      const us = twoslasherLegacy(code, 'ts')
+      const us = await twoslasherLegacy(code, 'ts')
       const result = twoslasherOriginal(code, 'ts')
 
       function cleanup(t: any) {

--- a/packages/twoslash/test/modules.test.ts
+++ b/packages/twoslash/test/modules.test.ts
@@ -9,7 +9,7 @@ declare namespace G {
 export = G;
 `
 
-it('works with a dependency in @types for the project', () => {
+it('works with a dependency in @types for the project', async () => {
   const fsMap = createDefaultMapFromNodeModules({})
   fsMap.set('/node_modules/@types/glob/index.d.ts', dt)
 
@@ -18,7 +18,7 @@ import glob from "glob"
 glob.hasMagic("OK")
 //   ^?
   `
-  const result = twoslasher(file, 'ts', { fsMap })
+  const result = await twoslasher(file, 'ts', { fsMap })
   expect(result.errors).toEqual([])
   expect(result.queries[0].text!.includes('hasMagic')).toBeTruthy()
 })

--- a/packages/twoslash/test/new.test.ts
+++ b/packages/twoslash/test/new.test.ts
@@ -91,8 +91,8 @@ const value = absolute(-1)
   `)
 })
 
-it('should pass', () => {
-  const result = twoslasher(code, 'ts', {
+it('should pass', async () => {
+  const result = await twoslasher(code, 'ts', {
     tsModule: ts,
     vfsRoot: process.cwd(),
   })

--- a/packages/twoslash/test/queries.test.ts
+++ b/packages/twoslash/test/queries.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 import { createTwoslasher } from '../src/index'
 
-const twoslasher = createTwoslasher()
+const twoslasher = await createTwoslasher()
 
 it('works in a trivial case', () => {
   const file = `

--- a/packages/twoslash/test/tags.test.ts
+++ b/packages/twoslash/test/tags.test.ts
@@ -1,14 +1,14 @@
 import { expect, it } from 'vitest'
 import { twoslasher } from '../src/index'
 
-it('extracts custom tags', () => {
+it('extracts custom tags', async () => {
   const file = `
 // @thing: OK, sure
 const a = "123"
 // @thingTwo - This should stay (note the no ':')
 const b = 12331234
   `
-  const result = twoslasher(file, 'ts', { customTags: ['thing'] })
+  const result = await twoslasher(file, 'ts', { customTags: ['thing'] })
   expect(result.tags.length).toEqual(1)
 
   expect(result.code).toMatchInlineSnapshot(`
@@ -33,7 +33,7 @@ const b = 12331234
   `)
 })
 
-it('removes tags which are cut', () => {
+it('removes tags which are cut', async () => {
   const file = `
 // @thing: OK, sure
 const a = "123"
@@ -41,7 +41,7 @@ const a = "123"
 // @thing: This one only
 const another = ''
     `
-  const result = twoslasher(file, 'ts', { customTags: ['thing'] })
+  const result = await twoslasher(file, 'ts', { customTags: ['thing'] })
   expect(result.tags.length).toEqual(1)
 
   expect(result.code).toMatchInlineSnapshot(`


### PR DESCRIPTION
In my use case, I'm using [source-map](https://github.com/mozilla/source-map).
Its consumer can only be `async`. 

This PR is opened to make twoslash meet some async usage context.