### PR TITLE
feat: support spaces before cut comments

### DIFF
--- a/packages/twoslash/src/regexp.ts
+++ b/packages/twoslash/src/regexp.ts
@@ -2,7 +2,7 @@ export const reConfigBoolean = /^\/\/\s?@(\w+)$/mg
 export const reConfigValue = /^\/\/\s?@(\w+):\s?(.+)$/mg
 export const reAnnonateMarkers = /^\s*\/\/\s*\^(\?|\||\^+)( .*)?$/mg
 
-export const reCutBefore = /^\/\/\s?---cut(-before)?---\r?\n/mg
-export const reCutAfter = /^\/\/\s?---cut-after---$/mg
-export const reCutStart = /^\/\/\s?---cut-start---$/mg
-export const reCutEnd = /^\/\/\s?---cut-end---\r?\n/mg
+export const reCutBefore = /^[\t\v\f ]*\/\/\s?---cut(-before)?---\r?\n/mg
+export const reCutAfter = /^[\t\v\f ]*\/\/\s?---cut-after---$/mg
+export const reCutStart = /^[\t\v\f ]*\/\/\s?---cut-start---$/mg
+export const reCutEnd = /^[\t\v\f ]*\/\/\s?---cut-end---\r?\n/mg

--- a/packages/twoslash/test/cutting.test.ts
+++ b/packages/twoslash/test/cutting.test.ts
@@ -126,3 +126,17 @@ describe('supports carriage return', () => {
     expect(hover1?.line).toEqual(hover2?.line)
   })
 })
+
+describe('supports space before cut comments', () => {
+  const file1 = `function foo() {\n  const x = "123"\n// ---cut-start---\n  /** @type {"345"} */\n// ---cut-end---\n  const b = "345"\n}`
+  const file2 = `function foo() {\n  const x = "123"\n  // ---cut-start---\n  /** @type {"345"} */\n  // ---cut-end---\n  const b = "345"\n}`
+  const result1 = twoslasher(file1, 'ts')
+  const result2 = twoslasher(file2, 'ts')
+
+  it('hover is on the same line', () => {
+    const hover1 = result1.hovers.find(info => info.text.includes('const b'))
+    const hover2 = result2.hovers.find(info => info.text.includes('const b'))
+
+    expect(hover1?.line).toEqual(hover2?.line)
+  })
+})


### PR DESCRIPTION
Currently twoslash requires the cut comment to be at the beginning of the line.
If I wanted to cut out the type comment for a variable in a function, I have to write it like below.
```js
function foo() {
  const x = "123"
// ---cut-start---
  /** @type {"345"} */
// ---cut-end---
  const b = "345"
}
```
But if that project uses prettier, it will be formatted and the comments will have a space before the `//` like below.
```js
function foo() {
  const x = "123"
  // ---cut-start---
  /** @type {"345"} */
  // ---cut-end---
  const b = "345"
}
```
So I'll have to disable prettier for this part of the code (https://github.com/vitejs/vite/blob/48a2bbb9994f9cd67e3d7455a57f6579f64e784d/docs/config/build-options.md?plain=1#L51-L66).

This PR allows the cut comment to have space characters before.
