### PR TITLE
fix: import ts from `typescript` instead of `typescript/lib/tsserver`

### DIFF
--- a/packages/twoslash-cdn/src/index.ts
+++ b/packages/twoslash-cdn/src/index.ts
@@ -1,6 +1,6 @@
 import type { TwoslashExecuteOptions, TwoslashFunction, TwoslashOptions, TwoslashReturn } from 'twoslash'
 import { createTwoslasher } from 'twoslash'
-import * as ts from 'typescript/lib/tsserverlibrary'
+import * as ts from 'typescript/lib/tsserverlibrary.js'
 import { createDefaultMapFromCDN } from '@typescript/vfs'
 import { setupTypeAcquisition } from '@typescript/ata'
 

--- a/packages/twoslash-cdn/src/index.ts
+++ b/packages/twoslash-cdn/src/index.ts
@@ -1,6 +1,6 @@
 import type { TwoslashExecuteOptions, TwoslashFunction, TwoslashOptions, TwoslashReturn } from 'twoslash'
 import { createTwoslasher } from 'twoslash'
-import * as ts from 'typescript/lib/tsserverlibrary.js'
+import ts from 'typescript'
 import { createDefaultMapFromCDN } from '@typescript/vfs'
 import { setupTypeAcquisition } from '@typescript/ata'
 

--- a/packages/twoslash/test/new.test.ts
+++ b/packages/twoslash/test/new.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest'
-import * as ts from 'typescript/lib/tsserverlibrary'
+import * as ts from 'typescript/lib/tsserverlibrary.js'
 import { splitFiles } from '../src/utils'
 import type { TwoslashReturn } from '../src/types'
 import { twoslasher } from '../src'

--- a/packages/twoslash/test/new.test.ts
+++ b/packages/twoslash/test/new.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest'
-import * as ts from 'typescript/lib/tsserverlibrary.js'
+import ts from 'typescript'
 import { splitFiles } from '../src/utils'
 import type { TwoslashReturn } from '../src/types'
 import { twoslasher } from '../src'


### PR DESCRIPTION
Changed this to .js instead of 'typescript', as this will work better with versions of TypeScript before 5.3.