### PR TITLE
feat: add `fsCache` option to improve build performance

### DIFF
--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -500,7 +500,13 @@ export function createTwoslasher(createOptions: CreateTwoslashOptions = {}): Two
   return twoslasher
 }
 
-function createCacheableFSBackedSystem(vfs: Map<string, string>, root: string, ts: TS, tsLibDirectory?: string, enableFsCache = false): System {
+function createCacheableFSBackedSystem(
+  vfs: Map<string, string>,
+  root: string,
+  ts: TS,
+  tsLibDirectory?: string,
+  enableFsCache = true,
+): System {
   function withCache<T>(fn: (key: string) => T) {
     const cache = new Map<string, T>()
     return (key: string) => {

--- a/packages/twoslash/src/types/options.ts
+++ b/packages/twoslash/src/types/options.ts
@@ -85,4 +85,9 @@ export interface CreateTwoslashOptions extends TwoslashExecuteOptions {
    * Cache the ts envs based on compiler options, defaults to true
    */
   cache?: boolean | Map<string, VirtualTypeScriptEnvironment>
+
+  /**
+   * Cache file system requests, defaults to false
+   */
+  fsCache?: boolean
 }

--- a/packages/twoslash/src/types/options.ts
+++ b/packages/twoslash/src/types/options.ts
@@ -87,7 +87,9 @@ export interface CreateTwoslashOptions extends TwoslashExecuteOptions {
   cache?: boolean | Map<string, VirtualTypeScriptEnvironment>
 
   /**
-   * Cache file system requests, defaults to false
+   * Cache file system requests
+   *
+   * @default true
    */
   fsCache?: boolean
 }


### PR DESCRIPTION
This PR adds `fsCache` option that makes FS requests to be cached.

When this flag is enabled, `vitepress build` in [vitejs/vite](https://github.com/vitejs/vite/) gets 2x speed up.

> 41.72s -> 19.08s (without readFile cache: 25.41s)

I made the default to be `false` so it needs to be set to `true` by `@shikijs/vitepress-twoslash` for build. That said, I didn't find a way to know whether it is dev mode or build mode in `ShikiTransformer` type. Adding a way to know that might be also needed.
