### PR TITLE
fix(twoslash): improve cuts parser & error messages

### DIFF
--- a/packages/twoslash/src/regexp.ts
+++ b/packages/twoslash/src/regexp.ts
@@ -2,8 +2,8 @@ export const reConfigBoolean = /^\/\/\s?@(\w+)$/gm
 export const reConfigValue = /^\/\/\s?@(\w+):\s?(.+)$/gm
 export const reAnnonateMarkers = /^\s*\/\/\s*\^(\?|\||\^+)( .*)?$/gm
 
-export const reCutBefore = /^[\t\v\f ]*\/\/\s?---cut(-before)?---\r?\n/gm
-export const reCutAfter = /^[\t\v\f ]*\/\/\s?---cut-after---$/gm
-export const reCutStart = /^[\t\v\f ]*\/\/\s?---cut-start---$/gm
-export const reCutEnd = /^[\t\v\f ]*\/\/\s?---cut-end---\r?\n/gm
+export const reCutBefore = /^\/\/\s?---cut(-before)?---$/
+export const reCutAfter = /^\/\/\s?---cut-after---$/
+export const reCutStart = /^\/\/\s?---cut-start---$/
+export const reCutEnd = /^\/\/\s?---cut-end---$/
 export const reFilenamesMakers = /^[\t\v\f ]*\/\/\s?@filename: (.+)$/gm

--- a/packages/twoslash/test/cutting.test.ts
+++ b/packages/twoslash/test/cutting.test.ts
@@ -140,3 +140,10 @@ describe('supports space before cut comments', () => {
     expect(hover1?.line).toEqual(hover2?.line)
   })
 })
+
+describe('supports cut comments at end of file', () => {
+  const file1 = `const x = "123"\n// ---cut-start---\n  /** @type {"345"} */\n// ---cut-end---`
+  it('works without error', () => {
+    twoslasher(file1, 'ts')
+  })
+})

--- a/packages/twoslash/test/results/throws/unmatched-cut-range-count.txt
+++ b/packages/twoslash/test/results/throws/unmatched-cut-range-count.txt
@@ -1,6 +1,6 @@
 
 ## Mismatched cut markers
 
-You have 2 cut-starts and 1 cut-ends
+You have unclosed cut-starts at lines 60
 
 Make sure you have a matching pair for each.

--- a/packages/twoslash/test/results/throws/unmatched-cut-ranges.txt
+++ b/packages/twoslash/test/results/throws/unmatched-cut-ranges.txt
@@ -1,6 +1,6 @@
 
 ## Mismatched cut markers
 
-You have a cut-start at 57 which is after the cut-end at 12
+You have a cut-start at line 4 which is after the cut-end at line 2
 
 Make sure you have a matching pair for each.


### PR DESCRIPTION
fixes #76.

I think the current implementation can be faster by assuming a single line won't match multiple regexps, and as a side effect we can output line numbers instead of indexes, which is more helpful for debugging.

Please let me know if it's not desired.

- unit test added for original case
- tested again on existing unit tests