### PR TITLE
docs: fix cut notation

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -55,7 +55,7 @@ x = [10, 'hello']
 // @errors: 2339
 let x: [string, number]
 x = ['hello', 10] // OK
-/// ---cut---
+// ---cut---
 console.log(x[0].substring(1))
 console.log(x[1].substring(1))
 ```


### PR DESCRIPTION
I believe this was intended to actually cut the top portion, just like the official TS doc example.