### PR TITLE
chore: update deps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@types/react-dom': ^19.1.7
   '@typescript/ata': ^0.9.8
   '@typescript/twoslash': ^3.2.9
-  '@typescript/vfs': ^1.6.1
+  '@typescript/vfs': ^1.6.2
   '@unocss/reset': ^66.4.2
   '@vitest/coverage-v8': ^3.2.4
   '@vue/language-core': ^3.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ catalog:
   '@types/react': ^19.1.9
   '@types/react-dom': ^19.1.7
   '@typescript/ata': ^0.9.8
-  '@typescript/twoslash': ^3.2.9
+  '@typescript/twoslash': ^3.2.10
   '@typescript/vfs': ^1.6.2
   '@unocss/reset': ^66.4.2
   '@vitest/coverage-v8': ^3.2.4


### PR DESCRIPTION
Update `@typescript` dependencies to their latest version to support Node 25. ([`@typescript/vfs@1.6.2`](https://github.com/microsoft/TypeScript-Website/releases/tag/%40typescript%2Fvfs%401.6.2), [`@typescript/twoslash@3.2.10`](https://github.com/microsoft/TypeScript-Website/releases/tag/%40typescript%2Ftwoslash%403.2.10))