### PR TITLE
docs: fix dead links

### DIFF
--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -8,7 +8,7 @@ Consider `twoslash` as the successor of `@typescript/twoslash` that maintained a
 
 Breaking changes from `@typescript/twoslash`:
 
-1. The returned items have different signatures, and different types of the items (`staticQuickInfo`, `queries`, `errors`, `tags`) are now unified into a single array `nodes`. Learn more at the [Information Nodes](#information-nodes) section.
+1. The returned items have different signatures, and different types of the items (`staticQuickInfo`, `queries`, `errors`, `tags`) are now unified into a single array `nodes`. Learn more at the [Information Nodes](/refs/result#information-nodes) section.
 2. Main entry point `import {} from "twoslash"` dependent on `typescript` package, while a new sub-entry `import {} from "twoslash/core"` is dependency-free and requires providing your own TypeScript instance.
 3. `defaultOptions` is renamed to `handbookOptions`.
 4. `defaultCompilerOptions` is renamed to `compilerOptions`.

--- a/docs/refs/result.md
+++ b/docs/refs/result.md
@@ -30,7 +30,7 @@ Check the [type definition](https://github.com/antfu/twoslashes/blob/main/packag
 
 ## Information Nodes
 
-Twoslash returns all types of information in the `nodes` array. Check the [type definition](https://github.com/antfu/twoslashes/blob/main/packages/twoslash/src/types/nodes.ts) for all the fields.
+Twoslash returns all types of information in the `nodes` array. Check the [type definition](https://github.com/twoslashes/twoslash/blob/main/packages/twoslash-protocol/src/types/nodes.ts) for all the fields.
 
 ### Properties
 


### PR DESCRIPTION
Also noticed that there is an empty link at https://github.com/twoslashes/twoslash/blob/8a98d63be3d3f4bdfb18a4c2ccaec58aef25bb6f/docs/refs/api.md?plain=1#L19