### PR TITLE
fix(vue): remove writeGlobalTypes

### DIFF
--- a/packages/twoslash-vue/src/index.ts
+++ b/packages/twoslash-vue/src/index.ts
@@ -16,7 +16,6 @@ import {
   createVueLanguagePlugin,
   defaultMapperFactory,
   FileMap,
-  writeGlobalTypes,
 } from '@vue/language-core'
 import {
   createTwoslasher as createTwoslasherBase,
@@ -75,7 +74,6 @@ export function createTwoslasher(createOptions: CreateTwoslashVueOptions = {}): 
       const resolver = new CompilerOptionsResolver(ts.sys.fileExists)
       resolver.addConfig(vueCompilerOptions, ts.sys.getCurrentDirectory())
       const vueOptions = resolver.build()
-      writeGlobalTypes(vueOptions, ts.sys.writeFile)
       const vueLanguagePlugin = createVueLanguagePlugin<string>(ts, compilerOptions, vueOptions, id => id)
       return createLanguage(
         [vueLanguagePlugin],


### PR DESCRIPTION
**Problem**

twoslash-vue fails with newer versions of `@vue/language-core (3.1.1+)` due to importing writeGlobalTypes, which is no longer exported:
```
SyntaxError: The requested module '@vue/language-core' does not provide an export named 'writeGlobalTypes'
This breaks projects using twoslash-vue with newer @vue/language-core versions (e.g., Slidev).
```

This breaks projects using `twoslash-vue` with newer `@vue/language-core` versions (e.g., Slidev).

**Solution**

- Removed the `writeGlobalTypes` import from `@vue/language-core`
- Removed the `writeGlobalTypes(vueOptions, ts.sys.writeFile)` call

In `@vue/language-core 3.1.1+`, `writeGlobalTypes` was reimplemented without side effects and is handled internally by the Vue language plugin, so the explicit call is no longer needed.

**Changes**

- Removed unused `writeGlobalTypes` import
- Removed `writeGlobalTypes()` call in `getLanguage()`
- Kept `CompilerOptionsResolver` for Vue compiler options resolution

**Testing**

- Build passes
- No linting errors
- Type checks pass
- Existing functionality preserved