### PR TITLE
fix(twoslash-svelte): improve type resolving logic

### DIFF
--- a/docs/packages/svelte.md
+++ b/docs/packages/svelte.md
@@ -33,23 +33,17 @@ For example:
 ::: code-group
 
 ```bash [npm]
-npm i -D twoslash-svelte svelte2tsx
+npm i -D twoslash-svelte
 ```
 ```bash [pnpm]
-pnpm i -D twoslash-svelte svelte2tsx
+pnpm i -D twoslash-svelte
 ```
 ```bash [yarn]
-yarn add -D twoslash-svelte svelte2tsx
+yarn add -D twoslash-svelte
 ```
 ```bash [bun]
-bun add -D twoslash-svelte svelte2tsx
+bun add -D twoslash-svelte
 ```
-
-:::
-
-::: info Required Types
-
-`twoslash-svelte` requires `svelte2tsx` to be installed so that required declaration files are present during compilation of the Svelte code. Without `svelte2tsx` installed you might see errors like: `Cannot find name 'svelteHTML'.`
 
 :::
 

--- a/packages/twoslash-svelte/package.json
+++ b/packages/twoslash-svelte/package.json
@@ -46,12 +46,12 @@
     "start": "esno src/index.ts"
   },
   "peerDependencies": {
-    "svelte2tsx": "*",
     "typescript": "*"
   },
   "dependencies": {
     "@jridgewell/sourcemap-codec": "catalog:",
     "@volar/language-core": "catalog:",
+    "svelte2tsx": "catalog:",
     "twoslash": "workspace:*",
     "twoslash-protocol": "workspace:*"
   },

--- a/packages/twoslash-svelte/src/index.ts
+++ b/packages/twoslash-svelte/src/index.ts
@@ -1,7 +1,6 @@
 import type { CodeMapping } from '@volar/language-core'
 import type { CompilerOptionDeclaration, CreateTwoslashOptions, HandbookOptions, Range, TwoslashExecuteOptions, TwoslashInstance, TwoslashReturnMeta } from 'twoslash'
 import { createRequire } from 'node:module'
-import { join } from 'node:path'
 import { decode } from '@jridgewell/sourcemap-codec'
 import { SourceMap } from '@volar/language-core'
 import { svelte2tsx } from 'svelte2tsx'
@@ -16,6 +15,12 @@ export interface CreateTwoslashSvelteOptions extends CreateTwoslashOptions {
    * @default false
    */
   debugShowGeneratedCode?: boolean
+  /**
+   * Use the version 4 definitions for Svelte.
+   *
+   * @default false
+   */
+  useVersion4TypeDefinitions?: boolean
 }
 
 /**
@@ -88,18 +93,21 @@ export function createTwoslasher(createOptions: CreateTwoslashSvelteOptions = {}
       }
       return offsets[offsets.length - 1]?.[0]
     }
-    const svelte2tsxPath = require.resolve('svelte2tsx')
-    const result = _twoslasher(compiled.code, 'tsx', {
+    const svelte2tsxPackageJsonPath = require.resolve('svelte2tsx/package.json')
+
+    const references = createOptions.useVersion4TypeDefinitions
+      ? [
+          `/// <reference path="${new URL('svelte-shims-v4.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
+          `/// <reference path="${new URL('svelte-jsx-v4.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
+        ]
+      : [
+          `/// <reference path="${new URL('svelte-shims.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
+          `/// <reference path="${new URL('svelte-jsx.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
+        ].join('\n')
+
+    const result = _twoslasher(`${references}\n${compiled.code}`, 'tsx', {
       ...options,
-      compilerOptions: {
-        types: [
-          join(svelte2tsxPath, '..', 'svelte-jsx'),
-          join(svelte2tsxPath, '..', 'svelte-jsx-v4'),
-          join(svelte2tsxPath, '..', 'svelte-shims'),
-          join(svelte2tsxPath, '..', 'svelte-shims-v4'),
-        ],
-        ...compilerOptions,
-      },
+      compilerOptions,
       handbookOptions: {
         ...handbookOptions,
         keepNotations: true,

--- a/packages/twoslash-svelte/src/index.ts
+++ b/packages/twoslash-svelte/src/index.ts
@@ -4,7 +4,7 @@ import { createRequire } from 'node:module'
 import { decode } from '@jridgewell/sourcemap-codec'
 import { SourceMap } from '@volar/language-core'
 import { svelte2tsx } from 'svelte2tsx'
-import { createTwoslasher as _createTwoSlasher, defaultCompilerOptions, defaultHandbookOptions, findFlagNotations, findQueryMarkers } from 'twoslash'
+import { createTwoslasher as createTwoSlasherBase, defaultCompilerOptions, defaultHandbookOptions, findFlagNotations, findQueryMarkers } from 'twoslash'
 import { createPositionConverter, removeCodeRanges, resolveNodePositions } from 'twoslash-protocol'
 import ts from 'typescript'
 
@@ -15,12 +15,6 @@ export interface CreateTwoslashSvelteOptions extends CreateTwoslashOptions {
    * @default false
    */
   debugShowGeneratedCode?: boolean
-  /**
-   * Use the version 4 definitions for Svelte.
-   *
-   * @default false
-   */
-  useVersion4TypeDefinitions?: boolean
 }
 
 /**
@@ -28,11 +22,11 @@ export interface CreateTwoslashSvelteOptions extends CreateTwoslashOptions {
  */
 export function createTwoslasher(createOptions: CreateTwoslashSvelteOptions = {}): TwoslashInstance {
   const require = createRequire(import.meta.url)
-  const _twoslasher = _createTwoSlasher(createOptions)
+  const twoslasherBase = createTwoSlasherBase(createOptions)
 
   function twoslasher(code: string, extension?: string, options: TwoslashExecuteOptions = {}) {
     if (extension !== 'svelte') {
-      return _twoslasher(code, extension, options)
+      return twoslasherBase(code, extension, options)
     }
 
     const compilerOptions: ts.CompilerOptions = {
@@ -93,21 +87,17 @@ export function createTwoslasher(createOptions: CreateTwoslashSvelteOptions = {}
       }
       return offsets[offsets.length - 1]?.[0]
     }
-    const svelte2tsxPackageJsonPath = require.resolve('svelte2tsx/package.json')
 
-    const references = createOptions.useVersion4TypeDefinitions
-      ? [
-          `/// <reference path="${new URL('svelte-shims-v4.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
-          `/// <reference path="${new URL('svelte-jsx-v4.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
-        ]
-      : [
-          `/// <reference path="${new URL('svelte-shims.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
-          `/// <reference path="${new URL('svelte-jsx.d.ts', svelte2tsxPackageJsonPath).pathname}" />`,
-        ].join('\n')
-
-    const result = _twoslasher(`${references}\n${compiled.code}`, 'tsx', {
+    const result = twoslasherBase(compiled.code, 'tsx', {
       ...options,
-      compilerOptions,
+      compilerOptions: {
+        ...compilerOptions,
+        types: [
+          ...(compilerOptions.types ?? []),
+          require.resolve(`svelte2tsx/svelte-jsx-v4.d.ts`),
+          require.resolve(`svelte2tsx/svelte-shims-v4.d.ts`),
+        ],
+      },
       handbookOptions: {
         ...handbookOptions,
         keepNotations: true,
@@ -193,7 +183,7 @@ export function createTwoslasher(createOptions: CreateTwoslashSvelteOptions = {}
     return result
   }
 
-  twoslasher.getCacheMap = _twoslasher.getCacheMap
+  twoslasher.getCacheMap = twoslasherBase.getCacheMap
 
   return twoslasher
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ catalogs:
     svelte:
       specifier: ^5.25.3
       version: 5.56.1
+    svelte2tsx:
+      specifier: ^0.7.56
+      version: 0.7.56
     tslib:
       specifier: ^2.8.1
       version: 2.8.1
@@ -448,7 +451,7 @@ importers:
         specifier: 'catalog:'
         version: 2.4.28
       svelte2tsx:
-        specifier: '*'
+        specifier: 'catalog:'
         version: 0.7.56(svelte@5.56.1(@typescript-eslint/types@8.58.1))(typescript@6.0.2)
       twoslash:
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,7 @@ catalog:
   shiki: ^4.0.2
   simple-git-hooks: ^2.13.1
   svelte: ^5.25.3
+  svelte2tsx: ^0.7.56
   tslib: ^2.8.1
   typescript: ^6.0.2
   unbuild: ^3.6.1


### PR DESCRIPTION
This PR fixes some initial issues around resolving the required types for `svelte2tsx` and removes the need for the peer dependency of `svelte2tsx`.